### PR TITLE
fix: remove zeitwerk dependency.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     unicode-display_width (2.2.0)
-    zeitwerk (2.6.0)
 
 PLATFORMS
   x86_64-linux
@@ -63,7 +62,6 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 1.21)
   simplecov
-  zeitwerk (~> 2.6.0)
 
 BUNDLED WITH
    2.3.21

--- a/lib/miti.rb
+++ b/lib/miti.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-require_relative "miti/version"
-require "zeitwerk"
 require "date"
-
-loader = Zeitwerk::Loader.for_gem
-loader.setup # ready!
+require_relative "miti/ad_to_bs"
+require_relative "miti/bs_to_ad"
+require_relative "miti/nepali_date"
 
 # Base module for the gem
 module Miti

--- a/lib/miti/bs_to_ad.rb
+++ b/lib/miti/bs_to_ad.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./nepali_date"
 require "date"
 
 module Miti

--- a/lib/miti/nepali_date.rb
+++ b/lib/miti/nepali_date.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "data/date_data"
+
 module Miti
   # Class for nepali date
   class NepaliDate

--- a/miti.gemspec
+++ b/miti.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
-  spec.add_development_dependency "zeitwerk", "~> 2.6.0"
 end


### PR DESCRIPTION
This PR contains changes regarding removal of **zeitwerk** autoloader. This was done since the gem is very minimal and dependencies can be avoided. The other changes includes requiring of files from other files in case a file don't recognize other files.