### PR TITLE
Miti 10 bug custom error handling for nepali date#to s

### DIFF
--- a/lib/miti/nepali_date.rb
+++ b/lib/miti/nepali_date.rb
@@ -48,9 +48,7 @@ module Miti
     def to_s(separator: "-")
       return unless [" ", "/", "-"].include?(seperator)
 
-      [barsa, mahina, gatey].reduce("") do |final_date, date_element|
-        "#{final_date}#{final_date.blank? ? "" : seperator}#{date_element < 10 ? 0 : ""}#{date_element}"
-      end
+      barsa.to_s + separator + double_digit(mahina) + separator + double_digit(gatey)
     end
 
     ##
@@ -118,6 +116,14 @@ module Miti
 
         raise "Invalid date. The supplied gatey value exceeds the max available gatey for the mahina."
       end
+    end
+
+    private
+
+    def double_digit(value)
+      return "0#{value}" if value < 10
+
+      value.to_s
     end
   end
 end

--- a/lib/miti/nepali_date.rb
+++ b/lib/miti/nepali_date.rb
@@ -5,6 +5,7 @@ require_relative "data/date_data"
 module Miti
   # Class for nepali date
   class NepaliDate
+    class InvalidSeparatorError < StandardError; end
     attr_reader :barsa, :mahina, :gatey
 
     ##
@@ -46,7 +47,7 @@ module Miti
     #
     # @return [String]
     def to_s(separator: "-")
-      return unless [" ", "/", "-"].include?(seperator)
+      raise InvalidSeparatorError, "Invalid separator provided." unless [" ", "/", "-"].include?(separator)
 
       barsa.to_s + separator + double_digit(mahina) + separator + double_digit(gatey)
     end

--- a/lib/miti/nepali_date.rb
+++ b/lib/miti/nepali_date.rb
@@ -45,7 +45,7 @@ module Miti
     # @param separator(- by default)
     #
     # @return [String]
-    def to_s(seperator = "-")
+    def to_s(separator: "-")
       return unless [" ", "/", "-"].include?(seperator)
 
       [barsa, mahina, gatey].reduce("") do |final_date, date_element|


### PR DESCRIPTION
This PR includes the bug fix for the [Issue#10](https://github.com/xkshitizx/miti/issues/10)
Changes made: <br>

- Rewrote `#to_s` method to simplify logic.
- Add  `InvalidSeparatorError` class to handle invalid separators