### PR TITLE
Add CLI command to get number of days remaining for 1st of next month

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,3 +43,17 @@ Output:
 ```ruby
 [2023-06-28 AD] June 28, 2023 Wednesday
 ```
+
+### **next**
+
+The `next` command informs about days remaning for 1st of next month and last day of current month in BS.
+
+Example(On Ashadh 15):
+
+    $ miti next
+
+Output:
+```ruby
+17 days left until 1st Shrawan
+Current month's last date => 31 Ashadh
+```

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -63,6 +63,16 @@ module Miti
       @shell.say(output_txt, @output_color)
     end
 
+    desc "next", "get remaining days for 1st of next month and last day of current month"
+    def next
+      next_month = Miti.to_bs(Date.today.to_s).next_month_first
+      days_left_description = "\n#{next_month[:days_left]} days left until 1st #{next_month[:month_name]}"
+      current_month_last_description = "Current month's last date => #{next_month[:antim_gatey]}"
+
+      @shell.say(days_left_description, :green)
+      @shell.say(current_month_last_description, :cyan)
+    end
+
     no_commands do
       def self.exit_on_failure?
         true

--- a/lib/miti/nepali_date.rb
+++ b/lib/miti/nepali_date.rb
@@ -77,6 +77,18 @@ module Miti
       days_before_month + gatey
     end
 
+    def next_month_first
+      current_year_calendar = Miti::Data::NEPALI_YEAR_MONTH_HASH[barsa]
+      next_month = mahina < 12 ? mahina : 0
+      antim_gatey = current_year_calendar[mahina - 1]
+
+      {
+        days_left: antim_gatey - gatey + 1,
+        month_name: NepaliDate.months_in_english[next_month],
+        antim_gatey: "#{antim_gatey} #{NepaliDate.months_in_english[mahina - 1]}"
+      }
+    end
+
     class << self
       def today
         AdToBs.new(Date.today).convert


### PR DESCRIPTION
closes #22 

### Note
This PR creates a command line option **next** which informs about days remaning for 1st of next month.

### Command
`miti next`

### Expected Output

> 17 days left until 1st [next month eg: 1st Shrawan]
> Current month's last date => [last date eg: 31 Ashadh]